### PR TITLE
Infra: 개발환경 docker 설정 완료

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 .env
+.env.docker
 
 ### STS ###
 .apt_generated

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:17
+WORKDIR /app
+COPY ./build/libs/be_provocation-0.0.1-SNAPSHOT.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,45 @@
-version: '3.8'
-
 services:
-  db: # MySQL 서비스
+  provocation-mysql-container: # MySQL 서비스
     image: mysql:8.0.33
     restart: always
     container_name: provocation-mysql-container
     ports:
       - 13306:3306
     environment: # 환경 변수 설정
-      - MYSQL_DATABASE=provocation
-      - MYSQL_ROOT_PASSWORD=0000  # MYSQL 패스워드 설정
-      - TZ=Asia/Seoul
+      - MYSQL_DATABASE=${MYSQL_DATABASE}
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+      - TZ=${TZ}
     command: # 명령어 실행
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
+    volumes:
+      - mysql-data:/var/lib/mysql
+    networks:
+      - provocation-network
+
+  app: # Spring Boot 애플리케이션 서비스
+    build:
+      context: .
+      dockerfile: Dockerfile
+    env_file:
+      - .env.docker
+    restart: always
+    container_name: provocation-springboot-container
+    ports:
+      - 8080:8080
+    environment:
+      - SPRING_DATASOURCE_URL=jdbc:mysql://provocation-mysql-container:3306/${MYSQL_DATABASE}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
+      - SPRING_DATASOURCE_USERNAME=${SPRING_DATASOURCE_USERNAME}
+      - SPRING_DATASOURCE_PASSWORD=${SPRING_DATASOURCE_PASSWORD}
+      - SPRING_JPA_HIBERNATE_DDL_AUTO=update
+      - TZ=${TZ}
+    depends_on:
+      - provocation-mysql-container
+    networks:
+      - provocation-network
+volumes:
+  mysql-data:
+
+networks:
+  provocation-network:
+    driver: bridge

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+server:
+  port: 7070
+
 spring:
   # .env import
   config:


### PR DESCRIPTION
## 🪺 Summary
팀원들이 개발환경에서 사용할 수 있도록 컨테이너 환경을 docker-compose로 구성했습니다.

주요내용은 아래와 같습니다.

1. Dockerfile을 선언해 springboot의 jar파일을 이미지로 만들도록 했습니다.
2. docker-compose.yml을 선언해 springboot와 mysql을 컨테이너로 만들어서 관리할 수 있도록 했습니다.
3. 이 과정에서 컨테이너 상의 springboot 실행 뿐만 아니라 로컬 상의 springboot의 실행도 가능할 수 있도록 env 파일을 로컬용과 도커용으로 구분했습니다. 즉, 컨테이너로 올려서 springboot를 사용하실 수도 있고, 인텔리제이 상에서 springboot를 실행해서 사용하실 수도 있습니다. 단, 두 경우 모두 컨테이너로 올라가있는 mysql에 연결됩니다.

주의사항은 아래와 같습니다.

1. 로컬 springboot(인텔리제이에서 실행한 경우)은 매번 실행할 때마다 변경사항이 바로 적용되어서 문제가 없습니다만, 도커 springboot는 변경사항을 적용해서 이미지를 재빌드해주어야합니다. 따라서 코드 작성 후 swagger로 테스트하실 때 `docker-compose -p provocation up --build -d `를 프로젝트 경로에서 실행해주셔야합니다.
2. 이러한 불편함을 없애고자 인텔리제이에서 실행할 경우 문제 없이 컨테이너 상의 db 연결이 가능하도록 해놓았으니 참고부탁드립니다.
3. 인텔리제이로 실행한 경우는 포트를 7070으로 접속해주시고, 도커로 띄워진 springboot 컨테이너에 접속하는 경우는 포트를 8080으로 해주시면 됩니다.

## 🌱 Issue Number
- #6

## 사진자료

docker 컨테이너로 띄워진 springboot application에 8080포트로 swagger 접속성공한 모습입니다.
<img width="1727" alt="image" src="https://github.com/user-attachments/assets/567bfb0b-85bd-4451-a14d-3ca05a0cd434">



## 🙏 To Reviewers
src 디렉토리를 마운트해서 인텔리제이 상에서 코드 변경이 있으면 실시간으로 docker image를 다시 생성하고 빌드하는 방법에 대해 고민을 해보았습니다만, JAVA가 컴파일러 언어이기도 하고 .jar로 실행되기 때문에 오히려 불필요한 빌드가 계속 일어나서 인텔리제이가 느려지더라구요.

이 부분에 대해 mvp 개발 완료 후 조금 더 찾아보겠습니다!

피드백 주시면 바로 수정하겠습니다!
