### PR TITLE
Feat: 이메일 인증 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 	// websocket
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
+	//email-verification
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 	//lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/be_provocation/BeProvocationApplication.java
+++ b/src/main/java/com/be_provocation/BeProvocationApplication.java
@@ -3,9 +3,11 @@ package com.be_provocation;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class BeProvocationApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/be_provocation/auth/config/MailConfig.java
+++ b/src/main/java/com/be_provocation/auth/config/MailConfig.java
@@ -1,0 +1,35 @@
+package com.be_provocation.auth.config;
+
+import java.util.Properties;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Configuration
+public class MailConfig {
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost("smtp.gmail.com");
+        mailSender.setPort(587);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.transport.protocol", "smtp");
+        props.put("mail.smtp.auth", "true");
+        props.put("mail.smtp.starttls.enable", "true");
+        props.put("mail.debug", "true");
+
+        return mailSender;
+    }
+}

--- a/src/main/java/com/be_provocation/auth/domain/EmailTask.java
+++ b/src/main/java/com/be_provocation/auth/domain/EmailTask.java
@@ -1,0 +1,16 @@
+package com.be_provocation.auth.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class EmailTask {
+
+    private final String to;
+    private final String subject;
+    private final String content;
+//    private final List<File> files;
+//    private final EmailTemplateType templateType;
+}
+

--- a/src/main/java/com/be_provocation/auth/domain/VerificationCode.java
+++ b/src/main/java/com/be_provocation/auth/domain/VerificationCode.java
@@ -1,0 +1,41 @@
+package com.be_provocation.auth.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class VerificationCode {
+
+    @Id
+    private String email;               // 이메일 (PK)
+
+    private String code;                // 인증 코드
+
+    private LocalDateTime expirationTime; // 유효기간
+
+    private boolean isVerified;
+
+    // 정적 팩토리 메서드로 toEntity 구현
+    public static VerificationCode toEntity(String email, String code) {
+        VerificationCode entity = new VerificationCode();
+        entity.email = email;
+        entity.code = code;
+        entity.expirationTime = LocalDateTime.now().plusMinutes(30); // 30분 유효기간
+        entity.isVerified = false;
+        return entity;
+    }
+
+    public void setVerified() {
+        isVerified = true;
+    }
+}

--- a/src/main/java/com/be_provocation/auth/dto/request/GetVerificationRequest.java
+++ b/src/main/java/com/be_provocation/auth/dto/request/GetVerificationRequest.java
@@ -1,0 +1,10 @@
+package com.be_provocation.auth.dto.request;
+
+import jakarta.validation.constraints.Pattern;
+
+public record GetVerificationRequest(
+        @Pattern(regexp = "^[a-zA-Z0-9._%+-]+@kyonggi\\.ac\\.kr$",
+                message = "이메일은 @kyonggi.ac.kr로 끝나야 합니다.")
+        String email
+) {
+}

--- a/src/main/java/com/be_provocation/auth/dto/request/VerifyRequest.java
+++ b/src/main/java/com/be_provocation/auth/dto/request/VerifyRequest.java
@@ -1,0 +1,7 @@
+package com.be_provocation.auth.dto.request;
+
+public record VerifyRequest(
+        String email,
+        String code
+) {
+}

--- a/src/main/java/com/be_provocation/auth/repository/VerificationCodeRepository.java
+++ b/src/main/java/com/be_provocation/auth/repository/VerificationCodeRepository.java
@@ -1,0 +1,9 @@
+package com.be_provocation.auth.repository;
+
+import com.be_provocation.auth.domain.VerificationCode;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VerificationCodeRepository extends JpaRepository<VerificationCode, String> {
+    Optional<VerificationCode> findByEmail(String email);
+}

--- a/src/main/java/com/be_provocation/auth/service/AuthService.java
+++ b/src/main/java/com/be_provocation/auth/service/AuthService.java
@@ -23,6 +23,7 @@ public class AuthService {
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final JwtTokenService jwtTokenService;
     private final PasswordEncoder passwordEncoder;
+    private final VerificationService verificationService;
 
     @Transactional
     public void signUp(SignUpRequest request, HttpServletResponse response) {
@@ -36,6 +37,12 @@ public class AuthService {
         if (isMemberRegistered(email)) {
             throw CheckmateException.from(ErrorCode.ACCOUNT_USERNAME_EXIST);
         }
+
+        if(!verificationService.isVerified(email)) {
+            throw CheckmateException.from(ErrorCode.VERIFICATION_REQUIRED);
+        }
+
+        verificationService.removeCode(email);
 
         String encodedPassword = passwordEncoder.encode(password);
 

--- a/src/main/java/com/be_provocation/auth/service/AuthService.java
+++ b/src/main/java/com/be_provocation/auth/service/AuthService.java
@@ -52,7 +52,7 @@ public class AuthService {
 
 
         if (!isMemberRegistered(email)) {
-            throw CheckmateException.from(ErrorCode.ACCOUNT_USERNAME_EXIST);
+            throw CheckmateException.from(ErrorCode.MEMBER_NOT_FOUND);
         }
 
         generateToken(email, password, response);

--- a/src/main/java/com/be_provocation/auth/service/AuthService.java
+++ b/src/main/java/com/be_provocation/auth/service/AuthService.java
@@ -52,7 +52,7 @@ public class AuthService {
 
 
         if (!isMemberRegistered(email)) {
-            throw CheckmateException.from(ErrorCode.MEMBER_NOT_FOUND);
+            throw CheckmateException.from(ErrorCode.INCORRECT_PASSWORD_OR_ACCOUNT);
         }
 
         generateToken(email, password, response);

--- a/src/main/java/com/be_provocation/auth/service/EmailAsyncService.java
+++ b/src/main/java/com/be_provocation/auth/service/EmailAsyncService.java
@@ -35,6 +35,7 @@ public class EmailAsyncService {
         body.append("<h3>안녕하세요 CheckMate입니다.</h3>");
         body.append("<h3>요청하신 인증 번호입니다.</h3>");
         body.append("<h1>").append(verificationCode).append("</h1>");
+        body.append("<h3>감사합니다.</h3>");
         String content = body.toString();
         log.debug("Sending email to: {}", LogSanitizerUtil.sanitizeForLog(to));
         emailQueue.add(new EmailTask(to, "Check Mate 인증번호입니다.", content));

--- a/src/main/java/com/be_provocation/auth/service/EmailAsyncService.java
+++ b/src/main/java/com/be_provocation/auth/service/EmailAsyncService.java
@@ -1,0 +1,85 @@
+package com.be_provocation.auth.service;
+
+import com.be_provocation.auth.domain.EmailTask;
+import com.be_provocation.auth.util.LogSanitizerUtil;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EmailAsyncService {
+
+    private static final int MAX_BATCH_SIZE = 10;
+    private static final BlockingQueue<EmailTask> emailQueue = new LinkedBlockingQueue<>();
+    private final JavaMailSender javaMailSender;
+
+    @Value("${spring.mail.username}")
+    private String sender;
+
+    @Async
+    public void sendEmailAsync(String to, String verificationCode) throws MessagingException {
+        StringBuilder body = new StringBuilder();
+        body.append("<h3>안녕하세요 CheckMate입니다.</h3>");
+        body.append("<h3>요청하신 인증 번호입니다.</h3>");
+        body.append("<h1>").append(verificationCode).append("</h1>");
+        String content = body.toString();
+        log.debug("Sending email to: {}", LogSanitizerUtil.sanitizeForLog(to));
+        emailQueue.add(new EmailTask(to, "Check Mate 인증번호입니다.", content));
+    }
+
+    @Async
+    @Scheduled(fixedRate = 1000)
+    public void processEmailQueue() {
+        try {
+            List<EmailTask> batch = new ArrayList<>();
+            EmailTask task;
+            while ((task = emailQueue.poll()) != null) {
+                batch.add(task);
+                if (batch.size() >= MAX_BATCH_SIZE) {
+                    sendBatchEmail(batch);
+                    batch.clear();
+                }
+            }
+            if (!batch.isEmpty()) {
+                sendBatchEmail(batch);
+            }
+        } catch (Exception e) {
+            log.debug("Error processing email queue: {}", e.getMessage(), e);
+        }
+    }
+
+    public void sendBatchEmail(List<EmailTask> emailTasks) throws MessagingException {
+        MimeMessage[] mimeMessages = new MimeMessage[emailTasks.size()];
+        for (int i = 0; i < emailTasks.size(); i++) {
+            EmailTask task = emailTasks.get(i);
+            MimeMessage message = javaMailSender.createMimeMessage();
+            MimeMessageHelper messageHelper = new MimeMessageHelper(message, false, "UTF-8");
+            messageHelper.setFrom(sender);
+            messageHelper.setTo(task.getTo());
+            messageHelper.setSubject(task.getSubject());
+            messageHelper.setText(task.getContent(), true);
+
+            mimeMessages[i] = message;
+        }
+
+        try {
+            javaMailSender.send(mimeMessages);
+        } catch (Exception e) {
+            log.error("Error sending batch email: {}", e.getMessage());
+        }
+        log.debug("Batch email sent successfully.");
+    }
+}

--- a/src/main/java/com/be_provocation/auth/service/VerificationService.java
+++ b/src/main/java/com/be_provocation/auth/service/VerificationService.java
@@ -69,10 +69,13 @@ public class VerificationService {
         }
     }
 
-//    @Transactional(readOnly = true)
-//    public boolean isVerified(String email) {
-//
-//    }
+    @Transactional(readOnly = true)
+    public boolean isVerified(String email) {
+        VerificationCode storedCode = verificationCodeRepository.findByEmail(email)
+                .orElseThrow(() -> CheckmateException.from(ErrorCode.VERIFICATION_REQUIRED));
+
+        return storedCode.isVerified();
+    }
 
     @Transactional
     public void removeCode(String email) {

--- a/src/main/java/com/be_provocation/auth/service/VerificationService.java
+++ b/src/main/java/com/be_provocation/auth/service/VerificationService.java
@@ -1,0 +1,81 @@
+package com.be_provocation.auth.service;
+
+import com.be_provocation.auth.domain.VerificationCode;
+import com.be_provocation.auth.dto.request.VerifyRequest;
+import com.be_provocation.auth.repository.VerificationCodeRepository;
+import com.be_provocation.global.exception.CheckmateException;
+import com.be_provocation.global.exception.ErrorCode;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.Random;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class VerificationService {
+
+    private final VerificationCodeRepository verificationCodeRepository;
+
+    @Transactional
+    public String generateVerificationCode(String email) {
+        Random random = new Random();
+        StringBuilder verificationCode = new StringBuilder();
+
+        for (int i = 0; i < 8; i++) { // 인증 코드 8자리
+            int index = random.nextInt(3); // 0~2까지 랜덤, 랜덤값으로 switch문 실행
+
+            switch (index) {
+                case 0 -> verificationCode.append((char) (random.nextInt(26) + 97)); // 소문자
+                case 1 -> verificationCode.append((char) (random.nextInt(26) + 65)); // 대문자
+                case 2 -> verificationCode.append(random.nextInt(10)); // 숫자
+            }
+        }
+
+        checkDuplicated(email);
+
+        // 정적 팩토리 메서드를 사용해 엔터티 생성
+        VerificationCode codeEntity = VerificationCode.toEntity(email, verificationCode.toString());
+
+        verificationCodeRepository.save(codeEntity); // DB에 저장
+        return verificationCode.toString();
+    }
+
+    @Transactional
+    public void verifyCode(VerifyRequest request) {
+        String email = request.email();
+        String inputCode = request.code();
+
+        VerificationCode storedCode = verificationCodeRepository.findByEmail(email)
+                .orElseThrow(() -> CheckmateException.from(ErrorCode.VERIFICATION_CODE_NOT_FOUND));
+
+        if(storedCode.getExpirationTime().isBefore(LocalDateTime.now())) {
+            throw CheckmateException.from(ErrorCode.VERIFICATION_CODE_EXPIRED);
+        }
+
+        if(!inputCode.equals(storedCode.getCode())) {
+            throw CheckmateException.from(ErrorCode.VERIFICATION_CODE_INCORRECT);
+        }
+
+        storedCode.setVerified();
+    }
+
+    @Transactional
+    public void checkDuplicated(String email) {
+        Optional<VerificationCode> code = verificationCodeRepository.findByEmail(email);
+        if(code.isPresent()) {
+            removeCode(email);
+        }
+    }
+
+//    @Transactional(readOnly = true)
+//    public boolean isVerified(String email) {
+//
+//    }
+
+    @Transactional
+    public void removeCode(String email) {
+        verificationCodeRepository.deleteById(email);
+    }
+}

--- a/src/main/java/com/be_provocation/auth/util/LogSanitizerUtil.java
+++ b/src/main/java/com/be_provocation/auth/util/LogSanitizerUtil.java
@@ -1,0 +1,22 @@
+package com.be_provocation.auth.util;
+
+import org.springframework.util.StringUtils;
+
+public class LogSanitizerUtil {
+
+    // 이메일 주소를 마스킹
+    public static String sanitizeForLog(String email) {
+        if (StringUtils.isEmpty(email) || !email.contains("@")) {
+            return email; // 유효하지 않은 이메일은 그대로 반환
+        }
+
+        String[] parts = email.split("@");
+        String localPart = parts[0]; // '@' 앞부분
+        String domainPart = parts[1]; // '@' 뒷부분
+
+        // 로컬 부분의 첫 글자만 남기고 나머지는 '*'
+        String maskedLocalPart = localPart.charAt(0) + "****";
+
+        return maskedLocalPart + "@" + domainPart;
+    }
+}

--- a/src/main/java/com/be_provocation/global/config/SecurityConfig.java
+++ b/src/main/java/com/be_provocation/global/config/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
                                 .requestMatchers("/swagger", "/swagger-ui.html", "/swagger-ui/**", "/api-docs", "/api-docs/**", "/v1/api-docs/**","/health-check/**")
                                 .permitAll()
                                 // 해당 API에 대해서는 모든 요청을 허가
-                                .requestMatchers("/auth/login","/auth/signup", "/auth/check-nickname").permitAll()
+                                .requestMatchers("/auth/login","/auth/signup", "/auth/check-nickname", "/auth/verification-code", "/auth/verify-code").permitAll()
                                 //.requestMatchers("/members/test").hasRole("USER")
                                 // USER 권한이 있어야 요청할 수 있음
                                 //.requestMatchers("/members/test").hasRole("USER")

--- a/src/main/java/com/be_provocation/global/exception/ErrorCode.java
+++ b/src/main/java/com/be_provocation/global/exception/ErrorCode.java
@@ -37,8 +37,11 @@ public enum ErrorCode {
     NOT_BEARER_TOKEN_TYPE(HttpStatus.UNAUTHORIZED, "Bearer 타입의 토큰이 아닙니다."),
     UNSUPPORTED_TOKEN_TYPE(HttpStatus.UNAUTHORIZED,"지원하지 않는 JWT 형식의 토큰입니다."),
     NEED_AUTH_TOKEN(HttpStatus.UNAUTHORIZED, "로그인이 필요한 서비스입니다."),
-    INCORRECT_PASSWORD_OR_ACCOUNT(HttpStatus.UNAUTHORIZED, "비밀번호가 틀렸거나, 해당 계정이 없습니다."),
+    INCORRECT_PASSWORD_OR_ACCOUNT(HttpStatus.UNAUTHORIZED, "비밀번호가 틀렸거나, 해당 계정이 존재하지 않습니다."),
     ACCOUNT_USERNAME_EXIST(HttpStatus.UNAUTHORIZED, "해당 계정이 존재합니다."),
+    VERIFICATION_CODE_NOT_FOUND(HttpStatus.NOT_FOUND, "인증 코드가 존재하지 않습니다."),
+    VERIFICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "만료된 인증 코드입니다."),
+    VERIFICATION_CODE_INCORRECT(HttpStatus.BAD_REQUEST, "올바르지 않은 인증코드입니다."),
 
     // others
     REQUEST_OK(HttpStatus.OK, "올바른 요청입니다."),

--- a/src/main/java/com/be_provocation/global/exception/ErrorCode.java
+++ b/src/main/java/com/be_provocation/global/exception/ErrorCode.java
@@ -42,6 +42,7 @@ public enum ErrorCode {
     VERIFICATION_CODE_NOT_FOUND(HttpStatus.NOT_FOUND, "인증 코드가 존재하지 않습니다."),
     VERIFICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "만료된 인증 코드입니다."),
     VERIFICATION_CODE_INCORRECT(HttpStatus.BAD_REQUEST, "올바르지 않은 인증코드입니다."),
+    VERIFICATION_REQUIRED(HttpStatus.BAD_REQUEST, "이메일 인증을 먼저 진행하세요."),
 
     // others
     REQUEST_OK(HttpStatus.OK, "올바른 요청입니다."),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,6 +31,24 @@ spring:
       token:
         expiration: ${JWT_ACCESS_TOKEN_EXPIRATION}
 
+  #Email 인증
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${SPRING_MAIL_USERNAME}
+    password: ${SPRING_MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
+    auth-code-expiration-millis: 1800000  # 30 * 60 * 1000 == 30?
+
 
 # Swagger 설정 추가
 springdoc:


### PR DESCRIPTION
## 🪺 Summary

자잘한 리팩토링 및 이메일 인증 기능 구현했습니다.
회원가입 API 요청시 해당 이메일이 인증 절차를 거치지 않았다면, 에러 발생시키도록 회원가입 로직 수정했습니다.

### 이메일 인증 코드 발행
![image](https://github.com/user-attachments/assets/272915f6-8ec6-40d7-b50c-ebab92733138)

## 🌱 Issue Number
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->
- #7 

## 🙏 To Reviewers
노션 회원가입 페이지와 이메일 인증 관련 페이지에 간단한 API 명세서 작성하였으니 참고해주세요!
그리고 .env도 바꼈으니 적용 부탁드립니다!