### PR TITLE
Fix: 해당 계정이 존재하지 않을 때, 비밀번호가 일치하지 않을 때 오류 발생시키는 로직 적용

### DIFF
--- a/src/main/java/com/be_provocation/auth/service/AuthService.java
+++ b/src/main/java/com/be_provocation/auth/service/AuthService.java
@@ -8,6 +8,7 @@ import com.be_provocation.global.exception.ErrorCode;
 import com.be_provocation.domain.member.domain.Member;
 import com.be_provocation.domain.member.repository.MemberRepository;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -57,9 +58,11 @@ public class AuthService {
         String email = request.email();
         String password = request.password();
 
+        Member findMember = memberRepository.findByEmail(email)
+                .orElseThrow(() -> CheckmateException.from(ErrorCode.INCORRECT_ACCOUNT));
 
-        if (!isMemberRegistered(email)) {
-            throw CheckmateException.from(ErrorCode.INCORRECT_PASSWORD_OR_ACCOUNT);
+        if(!passwordEncoder.matches(password, findMember.getPassword())) {
+            throw CheckmateException.from(ErrorCode.INCORRECT_PASSWORD);
         }
 
         generateToken(email, password, response);

--- a/src/main/java/com/be_provocation/global/exception/ErrorCode.java
+++ b/src/main/java/com/be_provocation/global/exception/ErrorCode.java
@@ -38,6 +38,8 @@ public enum ErrorCode {
     UNSUPPORTED_TOKEN_TYPE(HttpStatus.UNAUTHORIZED,"지원하지 않는 JWT 형식의 토큰입니다."),
     NEED_AUTH_TOKEN(HttpStatus.UNAUTHORIZED, "로그인이 필요한 서비스입니다."),
     INCORRECT_PASSWORD_OR_ACCOUNT(HttpStatus.UNAUTHORIZED, "비밀번호가 틀렸거나, 해당 계정이 존재하지 않습니다."),
+    INCORRECT_ACCOUNT(HttpStatus.UNAUTHORIZED, "해당 계정이 존재하지 않습니다."),
+    INCORRECT_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 틀렸습니다."),
     ACCOUNT_USERNAME_EXIST(HttpStatus.UNAUTHORIZED, "해당 계정이 존재합니다."),
     VERIFICATION_CODE_NOT_FOUND(HttpStatus.NOT_FOUND, "인증 코드가 존재하지 않습니다."),
     VERIFICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "만료된 인증 코드입니다."),


### PR DESCRIPTION
## 🪺 Summary
해당 계정이 존재하지 않을 때, DB에 존재하는 비밀번호와 다를때 오류 발생시키는 로직 적용했습니다.

## 🌱 Issue Number
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->
- #7 


## 🙏 To Reviewers
