### PR TITLE
Infra: 미니큐브를 활용한 다중 pod 관리 인프라 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,11 @@ plugins {
 group = 'com'
 version = '0.0.1-SNAPSHOT'
 
+springBoot {
+	mainClass = 'com.be_provocation.BeProvocationApplication'
+}
+
+
 java {
 	toolchain {
 		languageVersion = JavaLanguageVersion.of(17)

--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -1,0 +1,128 @@
+# MySQL ConfigMap
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+data:
+  MYSQL_DATABASE: "provocation"
+  TZ: "Asia/Seoul"
+  SPRING_DATASOURCE_URL: "jdbc:mysql://provocation-mysql:3306/provocation?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul"
+---
+# MySQL Secret
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-secret
+type: Opaque
+data:
+  MYSQL_ROOT_PASSWORD: MDAwMA==
+  SPRING_DATASOURCE_USERNAME: cm9vdA==
+  SPRING_DATASOURCE_PASSWORD: MDAwMA==
+---
+# MySQL Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: provocation-mysql
+  labels:
+    app: provocation-mysql
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: provocation-mysql
+  template:
+    metadata:
+      labels:
+        app: provocation-mysql
+    spec:
+      containers:
+        - name: mysql
+          image: mysql:8.0.33
+          ports:
+            - containerPort: 3306
+          env:
+            - name: MYSQL_DATABASE
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: MYSQL_DATABASE
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: app-secret
+                  key: MYSQL_ROOT_PASSWORD
+            - name: TZ
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: TZ
+          args:
+            - "--character-set-server=utf8mb4"
+            - "--collation-server=utf8mb4_unicode_ci"
+          volumeMounts:
+            - name: mysql-data
+              mountPath: /var/lib/mysql
+      volumes:
+        - name: mysql-data
+          hostPath:
+            path: /mnt/data/mysql
+            type: DirectoryOrCreate
+---
+# MySQL Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: provocation-mysql
+spec:
+  selector:
+    app: provocation-mysql
+  ports:
+    - protocol: TCP
+      port: 3306
+      targetPort: 3306
+---
+# Spring Boot Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: provocation-springboot
+  labels:
+    app: provocation-springboot
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: provocation-springboot
+  template:
+    metadata:
+      labels:
+        app: provocation-springboot
+    spec:
+      containers:
+        - name: springboot-app
+          image: checkmatekgu/provocation-springboot-container:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: app-config
+            - secretRef:
+                name: app-secret
+---
+# Spring Boot Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: provocation-springboot
+spec:
+  selector:
+    app: provocation-springboot
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+  type: LoadBalancer
+
+

--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -1,24 +1,3 @@
-# MySQL ConfigMap
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: app-config
-data:
-  MYSQL_DATABASE: "provocation"
-  TZ: "Asia/Seoul"
-  SPRING_DATASOURCE_URL: "jdbc:mysql://provocation-mysql:3306/provocation?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul"
----
-# MySQL Secret
-apiVersion: v1
-kind: Secret
-metadata:
-  name: app-secret
-type: Opaque
-data:
-  MYSQL_ROOT_PASSWORD: MDAwMA==
-  SPRING_DATASOURCE_USERNAME: cm9vdA==
-  SPRING_DATASOURCE_PASSWORD: MDAwMA==
----
 # MySQL Deployment
 apiVersion: apps/v1
 kind: Deployment

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,6 @@
 server:
-  port: 7070
+  port: 8080
+  address: 0.0.0.0
 
 spring:
   # .env import


### PR DESCRIPTION
## 🪺 Summary
미니큐브 환경에서 kubernetes.yaml을 실행시켜 다중 pod를 관리할 수 있도록 했습니다.
실행원리는 아래와 같습니다.

1. build.clean -> build.gralde로 .jar파일을 생성합니다.
2. DockerFile을 활용해서 .jar 파일을 기반으로 도커 이미지를 만들고 checkmate 구글 계정의 도커 허브에 올립니다.
3. 미니큐브를 start시키고 이번 작업에서 새로 작성한 kubernetes.yaml을 실행합니다. 이 파일에서 도커 허브의 springboot 이미지를 가져와서 컨테이너를 생성합니다. 물론 mysql 컨테이너도 생성합니다.
4. 3번 이전에 .env.docker 바탕으로 config와 secret 설정을 미니큐브에 등록해주어야 합니다. (관련 명령어는 보고서에 작성하도록 하겠습니다. 필요 시 저한테 문의 부탁드립니다!)
5. LoadBalancer로 service를 설정한 springboot 어플리케이션은 `http://127.0.0.1:8080/swagger-ui/index.html#/`를 통해 스웨거에 접속이 가능합니다.

## 🌱 Issue Number
- #17 


## 🙏 To Reviewers
실행 사진 입니다! 참고해주세요.

checkmate 구글 계정의 도커허브 레포지토리에 올라간 스프링부트 이미지
![image](https://github.com/user-attachments/assets/9b7588f4-47ee-46f4-96ad-427b1e6623fd)
미니큐브에 생성된 스프링부트 pod에 접속해서 스웨거를 확인한 이미지. 이때 밍밍몬이라는 닉네임으로 회원가입을 했기 때문에 이미 존재하는 닉네임이라고 뜸. 이를 통해 DB연결도 잘 됨을 확인함.
![image](https://github.com/user-attachments/assets/0000d562-41bc-42d1-9203-13a5671edfad)
미니큐브 상의 생성된 두 개의 pod 확인
<img width="720" alt="image" src="https://github.com/user-attachments/assets/88b1d75a-4002-4d8a-a356-e4b340454196">
