### PR TITLE
Feat: 너는 정보에 맞는 룸메이트 필터링 기능 구현

### DIFF
--- a/src/main/java/com/be_provocation/domain/info/controller/InfoController.java
+++ b/src/main/java/com/be_provocation/domain/info/controller/InfoController.java
@@ -38,10 +38,10 @@ public class InfoController {
 
     @GetMapping
     @Operation(summary = "룸메이트 필터링 API", description = "필터링된 룸메이트의 정보를 가져오하는 API입니다.")
-    public ApiResponse<List<FilteringResponse>> filtering(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+    public ApiResponse<FilteringResponse> filtering(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
         Member member = customUserDetails.getMember();
 
-        return new ApiResponse<List<FilteringResponse>>(infoService.filtering(member));
+        return new ApiResponse<>(infoService.filtering(member));
     }
 
 }

--- a/src/main/java/com/be_provocation/domain/info/controller/InfoController.java
+++ b/src/main/java/com/be_provocation/domain/info/controller/InfoController.java
@@ -2,6 +2,7 @@ package com.be_provocation.domain.info.controller;
 
 import com.be_provocation.auth.util.CustomUserDetails;
 import com.be_provocation.domain.info.dto.request.InfoSaveRequest;
+import com.be_provocation.domain.info.dto.response.FilteringResponse;
 import com.be_provocation.domain.info.service.InfoService;
 import com.be_provocation.domain.member.domain.Member;
 import com.be_provocation.global.domain.SuccessCode;
@@ -9,8 +10,10 @@ import com.be_provocation.global.dto.response.ApiResponse;
 import com.be_provocation.global.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,4 +35,13 @@ public class InfoController {
         infoService.save(request, member);
         return new ApiResponse<>(SuccessCode.REQUEST_OK);
     }
+
+    @GetMapping
+    @Operation(summary = "룸메이트 필터링 API", description = "필터링된 룸메이트의 정보를 가져오하는 API입니다.")
+    public ApiResponse<List<FilteringResponse>> filtering(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        Member member = customUserDetails.getMember();
+
+        return new ApiResponse<List<FilteringResponse>>(infoService.filtering(member));
+    }
+
 }

--- a/src/main/java/com/be_provocation/domain/info/domain/MyInfo.java
+++ b/src/main/java/com/be_provocation/domain/info/domain/MyInfo.java
@@ -76,7 +76,7 @@ public class MyInfo extends BaseEntity {
     }
 
     public FilteringResponse toFilteringResponse() {
-        return new FilteringResponse(this.id, member.getNickname(), member.getProfileImageUrl(),
+        return new FilteringResponse(this.id, member.getNickname(), member.getProfileImageUrl(), this.mbti,
                 this.studentId, this.birthYear, this.department, this.desiredCloseness.getDisplayName());
     }
 

--- a/src/main/java/com/be_provocation/domain/info/domain/MyInfo.java
+++ b/src/main/java/com/be_provocation/domain/info/domain/MyInfo.java
@@ -1,6 +1,7 @@
 package com.be_provocation.domain.info.domain;
 
 import com.be_provocation.domain.info.dto.request.InfoSaveRequest;
+import com.be_provocation.domain.info.dto.response.FilteringResponse;
 import com.be_provocation.domain.member.domain.Member;
 import com.be_provocation.global.domain.BaseEntity;
 import jakarta.persistence.Entity;
@@ -15,9 +16,11 @@ import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -70,6 +73,11 @@ public class MyInfo extends BaseEntity {
                 .ifPresent(value -> this.desiredCloseness = DesiredCloseness.fromDisplayName(value));
         Optional.ofNullable(request.myDepartment())
                 .ifPresent(value -> this.department = value);
+    }
+
+    public FilteringResponse toFilteringResponse() {
+        return new FilteringResponse(this.id, member.getNickname(), member.getProfileImageUrl(),
+                this.studentId, this.birthYear, this.department, this.desiredCloseness.getDisplayName());
     }
 
 }

--- a/src/main/java/com/be_provocation/domain/info/domain/YourInfo.java
+++ b/src/main/java/com/be_provocation/domain/info/domain/YourInfo.java
@@ -15,9 +15,11 @@ import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/be_provocation/domain/info/dto/response/FilteringResponse.java
+++ b/src/main/java/com/be_provocation/domain/info/dto/response/FilteringResponse.java
@@ -1,0 +1,12 @@
+package com.be_provocation.domain.info.dto.response;
+
+public record FilteringResponse
+        (Long myInfoId,
+         String nickname,
+         String profileImageUrl,
+         Integer studentId,
+         Integer birthYear,
+         String department,
+         String desiredCloseness
+        ) {
+}

--- a/src/main/java/com/be_provocation/domain/info/dto/response/FilteringResponse.java
+++ b/src/main/java/com/be_provocation/domain/info/dto/response/FilteringResponse.java
@@ -1,9 +1,12 @@
 package com.be_provocation.domain.info.dto.response;
 
+import com.be_provocation.domain.info.domain.MBTI;
+
 public record FilteringResponse
         (Long myInfoId,
          String nickname,
          String profileImageUrl,
+         MBTI mbti,
          Integer studentId,
          Integer birthYear,
          String department,

--- a/src/main/java/com/be_provocation/domain/info/repository/MyInfoRepository.java
+++ b/src/main/java/com/be_provocation/domain/info/repository/MyInfoRepository.java
@@ -1,10 +1,20 @@
 package com.be_provocation.domain.info.repository;
 
 import com.be_provocation.domain.info.domain.MyInfo;
+import com.be_provocation.domain.info.domain.SleepSensitivity;
+import com.be_provocation.domain.info.domain.SmokingStatus;
+import com.be_provocation.domain.info.domain.SnoringStatus;
+import com.be_provocation.domain.member.domain.Gender;
 import com.be_provocation.domain.member.domain.Member;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MyInfoRepository extends JpaRepository<MyInfo, Long> {
     Optional<MyInfo> findByMember(Member member);
+
+    List<MyInfo> findBySmokingStatusAndSnoringStatusAndSleepSensitivity(
+            SmokingStatus smokingStatus,
+            SnoringStatus snoringStatus,
+            SleepSensitivity sleepSensitivity);
 }

--- a/src/main/java/com/be_provocation/domain/info/service/InfoService.java
+++ b/src/main/java/com/be_provocation/domain/info/service/InfoService.java
@@ -1,12 +1,22 @@
 package com.be_provocation.domain.info.service;
 
 import com.be_provocation.domain.info.domain.MyInfo;
+import com.be_provocation.domain.info.domain.SleepSensitivity;
+import com.be_provocation.domain.info.domain.SmokingStatus;
+import com.be_provocation.domain.info.domain.SnoringStatus;
 import com.be_provocation.domain.info.domain.YourInfo;
 import com.be_provocation.domain.info.dto.request.InfoSaveRequest;
+import com.be_provocation.domain.info.dto.response.FilteringResponse;
 import com.be_provocation.domain.info.repository.MyInfoRepository;
 import com.be_provocation.domain.info.repository.YourInfoRepository;
+import com.be_provocation.domain.member.domain.Gender;
 import com.be_provocation.domain.member.domain.Member;
+import com.be_provocation.global.exception.CheckmateException;
+import com.be_provocation.global.exception.ErrorCode;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,4 +38,23 @@ public class InfoService {
         yourInfo.update(request);
     }
 
+    @Transactional(readOnly = true)
+    public List<FilteringResponse> filtering(Member member) {
+        YourInfo yourInfo = yourInfoRepository.findByMember(member).orElseThrow(() -> CheckmateException.from(ErrorCode.YOURINFO_NOT_FOUND));
+
+        Gender gender = member.getGender();
+        SmokingStatus smokingStatus = yourInfo.getSmokingStatus();
+        SnoringStatus snoringStatus = yourInfo.getSnoringStatus();
+        SleepSensitivity sleepSensitivity = yourInfo.getSleepSensitivity();
+
+        List<MyInfo> findMyInfos = myInfoRepository.findBySmokingStatusAndSnoringStatusAndSleepSensitivity(
+                smokingStatus, snoringStatus, sleepSensitivity);
+
+        return findMyInfos.stream()
+                .filter(myInfo -> !myInfo.getMember().getId().equals(member.getId())) // 내 정보는 빼고 필터링
+                .filter(myInfo -> myInfo.getMember().getGender().equals(gender)) // 동일 성별만 나오도록 필터링
+                .map(MyInfo::toFilteringResponse)
+                .collect(Collectors.toList());
+
+    }
 }

--- a/src/main/java/com/be_provocation/global/exception/ErrorCode.java
+++ b/src/main/java/com/be_provocation/global/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
     DUPLICATE_MEMBER_NICKNAME(HttpStatus.BAD_REQUEST, "중복된 닉네임입니다"),
     PROFILE_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "프로필 이미지를 찾을 수 없습니다"),
     MEMBER_NOT_ADMIN(HttpStatus.FORBIDDEN, "관리자가 아닙니다"),
+    YOURINFO_NOT_FOUND(HttpStatus.NOT_FOUND, "희망 룸메이트 정보를 찾을 수 없습니다."),
 
     // chat
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다."),


### PR DESCRIPTION
## 🪺 Summary

너는 정보에 맞는 룸메이트 필터링 기능 구현 완료했습니다.

## 🌱 Issue Number
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->
- #21 


## 🙏 To Reviewers
### Member 테이블
<img width="1754" alt="image" src="https://github.com/user-attachments/assets/6264323d-6352-4d91-8d7d-56ef4d89afb1">
위와 같이 4명의 멤버가 있고,

### YourInfo 테이블
<img width="1491" alt="image" src="https://github.com/user-attachments/assets/7fe5e79b-d467-4a20-9ddc-8e5ea1773ed9">
YourInfo 테이블의 1번 member_id가 원하는 룸메이트는 (잠귀)DEEP, (흡연)NON_SMOKER, (코골이)NO 입니다.

### MyInfo 테이블
<img width="2137" alt="image" src="https://github.com/user-attachments/assets/6e995e5c-61db-4dc0-9192-fb166a790e78">
MyInfo 테이블에는 4명의 정보가 들어있고, 1번 기준 필터링을 하면 4번을 제외한 나머지 3명의 정보가 정상적으로 출력됩니다!

### 결과
<img width="1412" alt="image" src="https://github.com/user-attachments/assets/e4112043-3a93-4a3f-b906-0df1a70004e1">
