### PR TITLE
Fix: 룸메이트의 희망 학과를 Enum으로 관리하도록 수정

### DIFF
--- a/src/main/java/com/be_provocation/domain/info/domain/DesiredDepartment.java
+++ b/src/main/java/com/be_provocation/domain/info/domain/DesiredDepartment.java
@@ -1,0 +1,28 @@
+package com.be_provocation.domain.info.domain;
+
+import com.be_provocation.global.exception.CheckmateException;
+import com.be_provocation.global.exception.ErrorCode;
+import java.util.Arrays;
+
+public enum DesiredDepartment {
+    SAME("같아야 함"),
+    DIFFERENT("달라야 함"),
+    NO_MATTER("상관 없음");
+
+    private final String displayName;
+
+    DesiredDepartment(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public static DesiredDepartment fromDisplayName(String displayName) {
+        return Arrays.stream(DesiredDepartment.values())
+                .filter(status -> status.getDisplayName().equals(displayName))
+                .findFirst()
+                .orElseThrow(() -> CheckmateException.from(ErrorCode.ENUM_CONVERSION_ERROR));
+    }
+}

--- a/src/main/java/com/be_provocation/domain/info/domain/YourInfo.java
+++ b/src/main/java/com/be_provocation/domain/info/domain/YourInfo.java
@@ -43,7 +43,8 @@ public class YourInfo extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private SleepSensitivity sleepSensitivity; // 잠귀 정도
 
-    private String department; // 학과
+    @Enumerated(EnumType.STRING)
+    private DesiredDepartment desiredDepartment; // 학과
 
     // request의 특정 값이 null일 경우 기존 값 유지
     public void update(InfoSaveRequest request) {
@@ -54,7 +55,7 @@ public class YourInfo extends BaseEntity {
         Optional.ofNullable(request.yourSleepSensitivity())
                 .ifPresent(value -> this.sleepSensitivity = SleepSensitivity.fromDisplayName(value));
         Optional.ofNullable(request.yourDepartment())
-                .ifPresent(value -> this.department = value);
+                .ifPresent(value -> this.desiredDepartment = DesiredDepartment.fromDisplayName(value));
     }
 
 }

--- a/src/main/java/com/be_provocation/domain/info/dto/request/InfoSaveRequest.java
+++ b/src/main/java/com/be_provocation/domain/info/dto/request/InfoSaveRequest.java
@@ -1,6 +1,7 @@
 package com.be_provocation.domain.info.dto.request;
 
 import com.be_provocation.domain.info.domain.DesiredCloseness;
+import com.be_provocation.domain.info.domain.DesiredDepartment;
 import com.be_provocation.domain.info.domain.MBTI;
 import com.be_provocation.domain.info.domain.MyInfo;
 import com.be_provocation.domain.info.domain.SleepSensitivity;
@@ -43,7 +44,7 @@ public record InfoSaveRequest(
                 .smokingStatus(SmokingStatus.fromDisplayName(yourSmokingStatus))
                 .snoringStatus(SnoringStatus.fromDisplayName(yourSnoringStatus))
                 .sleepSensitivity(SleepSensitivity.fromDisplayName(yourSleepSensitivity))
-                .department(yourDepartment)
+                .desiredDepartment(DesiredDepartment.fromDisplayName(yourDepartment))
                 .build();
     }
 }


### PR DESCRIPTION
## 🪺 Summary
룸메이트의 희망 학과를 
"같아야 함", "달라야 함", "상관 없음"으로 두어서 필터링 기능에서 사용할 수 있게 합니다.

⚠️그러나 현재 MyInfo를 입력 할 때 학과를 Stirng으로 직접 입력하게 되어있습니다.
따라서 String.equals로 학과 일치 여부를 판단한다면 컴퓨터공학전공, 컴퓨터공학과가 다른 학과로 인식됩니다.
따라서 학과 일치 여부를 필터링 기준에 넣는 것은 추후 확장성으로 열어두겠습니다. 

따라서 #28은 현재 MVP에서는 제외하도록 합니다.

## 🌱 Issue Number
- #27 

## 🙏 To Reviewers
프론트 연동 중에 발생한 문제를 수정한 작업입니다. 빠르게 피드백 주시면 감사할 것 같습니다!
@areian13 님도 원하시는 방향으로 수정됐는지 확인 부탁드려요!