### PR TITLE
Feat: 로그인한 사용자의 나는너는 정보를 조회하는 API 작성

### DIFF
--- a/src/main/java/com/be_provocation/domain/info/controller/InfoController.java
+++ b/src/main/java/com/be_provocation/domain/info/controller/InfoController.java
@@ -4,6 +4,7 @@ import com.be_provocation.auth.util.CustomUserDetails;
 import com.be_provocation.domain.info.dto.request.InfoSaveRequest;
 import com.be_provocation.domain.info.dto.response.DetailResponse;
 import com.be_provocation.domain.info.dto.response.FilteringResponse;
+import com.be_provocation.domain.info.dto.response.IamYouAreResponse;
 import com.be_provocation.domain.info.service.InfoService;
 import com.be_provocation.domain.member.domain.Member;
 import com.be_provocation.global.domain.SuccessCode;
@@ -45,6 +46,14 @@ public class InfoController {
     @Operation(summary = "룸메이트 정보 상세보기 API", description = "한 명의 룸메이트의 구체적인 정보를 가져오는 API입니다.")
     public ApiResponse<DetailResponse> getDetails(@PathVariable("myInfoId") Long myInfoId) {
         return new ApiResponse<>(infoService.getDetails(myInfoId));
+    }
+
+    @GetMapping("/my")
+    @Operation(summary = "나의 나는너는 정보 조회하기 API", description = "로그인한 사용자가 작성한 나는 너는 정보를 반환하는 API입니다.")
+    public ApiResponse<IamYouAreResponse> getMyIamYouAreInfo(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        Member member = customUserDetails.getMember();
+
+        return new ApiResponse<IamYouAreResponse>(infoService.getMyIamYouAreInfo(member));
     }
 
 }

--- a/src/main/java/com/be_provocation/domain/info/domain/SnoringStatus.java
+++ b/src/main/java/com/be_provocation/domain/info/domain/SnoringStatus.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
 public enum SnoringStatus {
     YES("O"),
     NO("X"),
-    SOMETIMES("피곤하면 가끔");
+    SOMETIMES("가끔");
 
     private final String displayName;
 

--- a/src/main/java/com/be_provocation/domain/info/dto/response/IamYouAreResponse.java
+++ b/src/main/java/com/be_provocation/domain/info/dto/response/IamYouAreResponse.java
@@ -1,0 +1,40 @@
+package com.be_provocation.domain.info.dto.response;
+
+import com.be_provocation.domain.info.domain.MBTI;
+import com.be_provocation.domain.info.domain.MyInfo;
+import com.be_provocation.domain.info.domain.YourInfo;
+import lombok.Builder;
+
+@Builder
+public record IamYouAreResponse(
+        MBTI myMBTI,
+        Integer myStudentId,
+        Integer myBirthYear,
+        String mySmokingStatus,
+        String mySnoringStatus,
+        String mySleepSensitivity,
+        String myDepartment,
+        String myDesiredCloseness,
+        String yourSmokingStatus,
+        String yourSnoringStatus,
+        String yourSleepSensitivity,
+        String yourDepartment
+) {
+    public static IamYouAreResponse toDto(MyInfo myInfo, YourInfo yourInfo) {
+        return IamYouAreResponse.builder().
+                myMBTI(myInfo.getMbti())
+                .myStudentId(myInfo.getStudentId())
+                .myBirthYear(myInfo.getBirthYear())
+                .mySmokingStatus(myInfo.getSmokingStatus().getDisplayName())
+                .mySnoringStatus(myInfo.getSnoringStatus().getDisplayName())
+                .mySleepSensitivity(myInfo.getSleepSensitivity().getDisplayName())
+                .myDepartment(myInfo.getDepartment())
+                .myDesiredCloseness(myInfo.getDesiredCloseness().getDisplayName())
+                .yourSmokingStatus(yourInfo.getSmokingStatus().getDisplayName())
+                .yourSnoringStatus(yourInfo.getSnoringStatus().getDisplayName())
+                .yourSleepSensitivity(yourInfo.getSleepSensitivity().getDisplayName())
+                .yourDepartment(yourInfo.getDesiredDepartment().getDisplayName())
+                .build();
+
+    }
+}

--- a/src/main/java/com/be_provocation/domain/info/service/InfoService.java
+++ b/src/main/java/com/be_provocation/domain/info/service/InfoService.java
@@ -8,6 +8,7 @@ import com.be_provocation.domain.info.domain.YourInfo;
 import com.be_provocation.domain.info.dto.request.InfoSaveRequest;
 import com.be_provocation.domain.info.dto.response.DetailResponse;
 import com.be_provocation.domain.info.dto.response.FilteringResponse;
+import com.be_provocation.domain.info.dto.response.IamYouAreResponse;
 import com.be_provocation.domain.info.repository.MyInfoRepository;
 import com.be_provocation.domain.info.repository.YourInfoRepository;
 import com.be_provocation.domain.member.domain.Gender;
@@ -57,6 +58,14 @@ public class InfoService {
                 .map(MyInfo::toFilteringResponse)
                 .collect(Collectors.toList());
 
+    }
+
+    @Transactional(readOnly = true)
+    public IamYouAreResponse getMyIamYouAreInfo(Member member) {
+        MyInfo myInfo = myInfoRepository.findByMember(member).orElseThrow(() -> CheckmateException.from(ErrorCode.MYINFO_NOT_FOUND));
+        YourInfo yourInfo = yourInfoRepository.findByMember(member).orElseThrow(() -> CheckmateException.from(ErrorCode.YOURINFO_NOT_FOUND));
+
+        return IamYouAreResponse.toDto(myInfo, yourInfo);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/be_provocation/global/exception/ErrorCode.java
+++ b/src/main/java/com/be_provocation/global/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
     DUPLICATE_MEMBER_NICKNAME(HttpStatus.BAD_REQUEST, "중복된 닉네임입니다"),
     PROFILE_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "프로필 이미지를 찾을 수 없습니다"),
     MEMBER_NOT_ADMIN(HttpStatus.FORBIDDEN, "관리자가 아닙니다"),
+    MYINFO_NOT_FOUND(HttpStatus.NOT_FOUND, "나는 정보를 찾을 수 없습니다."),
     YOURINFO_NOT_FOUND(HttpStatus.NOT_FOUND, "희망 룸메이트 정보를 찾을 수 없습니다."),
 
     // info


### PR DESCRIPTION
## 🪺 Summary
로그인한 사용자가 이전에 작성한 나는너는 정보를 가져와서 보여줄 수 있는 API를 작성했습니다.
이전에 작성한 정보가 없다면 404를 반환합니다. 이에 따라 프론트에서 경고창을 띄우도록 합니다.

⚠️프론트에서 코골이 여부를 "피곤할때 가끔" -> "가끔"으로 구현하셔서 이 부분도 함께 수정했습니다. 커밋 분리해서 작업하였으니 참고 부탁드립니다.

## 🌱 Issue Number
- #30 


## 🙏 To Reviewers
@areian13 님이 요청하신 API입니다. 요청, 응답 포멧을 확인해주시고 이상이 있다면 알려주세요!