### PR TITLE
Fix: 필터링 시 최적의 룸메이트를 상단에, 나머지 사용자를 하단에 배치하도록 수정 

### DIFF
--- a/src/main/java/com/be_provocation/domain/info/service/InfoService.java
+++ b/src/main/java/com/be_provocation/domain/info/service/InfoService.java
@@ -16,15 +16,19 @@ import com.be_provocation.domain.member.domain.Member;
 import com.be_provocation.global.exception.CheckmateException;
 import com.be_provocation.global.exception.ErrorCode;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class InfoService {
 
     private final MyInfoRepository myInfoRepository;
@@ -42,22 +46,46 @@ public class InfoService {
 
     @Transactional(readOnly = true)
     public List<FilteringResponse> filtering(Member member) {
-        YourInfo yourInfo = yourInfoRepository.findByMember(member).orElseThrow(() -> CheckmateException.from(ErrorCode.YOURINFO_NOT_FOUND));
+        YourInfo yourInfo;
+        try {
+            yourInfo = yourInfoRepository.findByMember(member)
+                    .orElseThrow(() -> CheckmateException.from(ErrorCode.YOURINFO_NOT_FOUND));
+        } catch (CheckmateException e) {
+            log.warn("YourInfo not found for member: {}. Fetching all MyInfo.", member.getId());
+            // 등록한 "나는 너는"이 없는 경우는 동일성별의 전체 사용자를 반환
+            return filterAndMapMyInfos(
+                    myInfoRepository.findAll(),
+                    member.getId(),
+                    member.getGender()
+            );
+        }
 
-        Gender gender = member.getGender();
-        SmokingStatus smokingStatus = yourInfo.getSmokingStatus();
-        SnoringStatus snoringStatus = yourInfo.getSnoringStatus();
-        SleepSensitivity sleepSensitivity = yourInfo.getSleepSensitivity();
+        // 등록한 "나는 너는"이 있다면 최적의 룸메를 상단에, 나머지 사용자를 하단에 보여주도록 조회
+        List<MyInfo> prioritizedInfos = getPrioritizedMyInfos(yourInfo);
+        return filterAndMapMyInfos(prioritizedInfos, member.getId(), member.getGender());
+    }
 
-        List<MyInfo> findMyInfos = myInfoRepository.findBySmokingStatusAndSnoringStatusAndSleepSensitivity(
-                smokingStatus, snoringStatus, sleepSensitivity);
+    private List<MyInfo> getPrioritizedMyInfos(YourInfo yourInfo) {
+        List<MyInfo> matchingInfos = myInfoRepository.findBySmokingStatusAndSnoringStatusAndSleepSensitivity(
+                yourInfo.getSmokingStatus(),
+                yourInfo.getSnoringStatus(),
+                yourInfo.getSleepSensitivity()
+        );
+        List<MyInfo> allInfos = myInfoRepository.findAll();
 
-        return findMyInfos.stream()
-                .filter(myInfo -> !myInfo.getMember().getId().equals(member.getId())) // 내 정보는 빼고 필터링
-                .filter(myInfo -> myInfo.getMember().getGender().equals(gender)) // 동일 성별만 나오도록 필터링
+        // Set을 사용하여 우선순위를 유지하면서 중복 제거
+        Set<MyInfo> prioritizedSet = new LinkedHashSet<>(matchingInfos);
+        prioritizedSet.addAll(allInfos);
+
+        return new ArrayList<>(prioritizedSet);
+    }
+
+    private List<FilteringResponse> filterAndMapMyInfos(List<MyInfo> myInfos, Long memberId, Gender gender) {
+        return myInfos.stream()
+                .filter(myInfo -> !myInfo.getMember().getId().equals(memberId)) // 내 정보는 제외
+                .filter(myInfo -> myInfo.getMember().getGender().equals(gender)) // 동일 성별만
                 .map(MyInfo::toFilteringResponse)
                 .collect(Collectors.toList());
-
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 🪺 Summary
이전에는 흡연, 코골이, 잠귀 기준이 모두 일치하는 룸메이트만 조회하도록 되어있었습니다.
이에 따라 홈화면에서 보여줄 수 있는 사용자가 아예 없는 경우도 존재하였습니다.

이를 개선하기 위해 최적의 룸메이트는 상단에, 나머지 사용자는 하단에 위치하도록 수정했습니다.

## 🌱 Issue Number

- #32


## 🙏 To Reviewers
응답 결과를 보시면 현재 로그인한 "밍밍몬"은 나는너는을 작성하지 않은 상태입니다. 그렇지만 다른 사용자인 "아리안"을 조회할 수 있는 모습입니다.
<img width="728" alt="image" src="https://github.com/user-attachments/assets/9c715557-90cd-49dc-9f54-4a79ff37d9f2">

이 작업은 @areian13 님과 연동작업을 하면서 홈화면 개선을 위해 진행된 것입니다.
