### PR TITLE
Fix: 예외처리 응답 시 http 상태코드를 설정할 수 있도록 수정 

### DIFF
--- a/src/main/java/com/be_provocation/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/be_provocation/global/handler/GlobalExceptionHandler.java
@@ -18,8 +18,13 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(CheckmateException.class)
-    public ApiResponse<Void> handle(CheckmateException e, HttpServletRequest request) {
-        return new ApiResponse<>(e);
+    public ResponseEntity<ApiResponse<Void>> handle(CheckmateException e, HttpServletRequest request) {
+        ErrorCode errorCode = e.getErrorCode();
+        HttpStatus status = errorCode.getStatus();
+
+        ApiResponse<Void> response = new ApiResponse<>(errorCode);
+
+        return ResponseEntity.status(status).body(response);
     }
 
     @Override


### PR DESCRIPTION
## 🪺 Summary
이전에는 예외처리 응답 시 http 응답이 responsebody에만 설정된 값으로 반환되었습니다. 따라서 프론트에서 onFailure로 예외처리가 불가능한 상태였습니다.

이를 해결하고자 예외처리 응답 시 http 상태코드를 응답자체에 설정할 수 있도록 하여 프론트에서 예외처리를 할 수 있도록 했습니다.

## 🌱 Issue Number
- #34


## 🙏 To Reviewers
빨간색으로 표시한 곳을 보시면 원래는 200으로 항상 표시된 것이 404로 표시된 것을 확인할 수 있습니다. 이는 백엔드에서 설정한 errorCode의 status에 따라서 동적으로 설정할 수 있습니다.
<img width="601" alt="image" src="https://github.com/user-attachments/assets/77f01fa3-5658-49c4-ada1-700779da6ae2">
