### PR TITLE
Feat: 로그인한 사용자의 프로필 조회 API 작성 (#36)

### DIFF
--- a/src/main/java/com/be_provocation/domain/member/controller/MemberController.java
+++ b/src/main/java/com/be_provocation/domain/member/controller/MemberController.java
@@ -1,0 +1,41 @@
+package com.be_provocation.domain.member.controller;
+
+import com.be_provocation.auth.util.CustomUserDetails;
+import com.be_provocation.domain.info.dto.request.InfoSaveRequest;
+import com.be_provocation.domain.info.dto.response.DetailResponse;
+import com.be_provocation.domain.info.dto.response.FilteringResponse;
+import com.be_provocation.domain.info.dto.response.IamYouAreResponse;
+import com.be_provocation.domain.info.service.InfoService;
+import com.be_provocation.domain.member.domain.Member;
+import com.be_provocation.domain.member.dto.response.MemberResponse;
+import com.be_provocation.domain.member.service.MemberService;
+import com.be_provocation.global.domain.SuccessCode;
+import com.be_provocation.global.dto.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/member")
+@RequiredArgsConstructor
+@Tag(name = "MemberController", description = "멤버 관련 API")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/my")
+    @Operation(summary = "내 프로필 조회하기 API", description = "로그인한 사용자의 프로필 정보를 반환하는 API입니다.")
+    public ApiResponse<MemberResponse> getMyProfile(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        Member member = customUserDetails.getMember();
+
+        return new ApiResponse<MemberResponse>(memberService.getMyProfile(member));
+    }
+
+}

--- a/src/main/java/com/be_provocation/domain/member/dto/response/MemberResponse.java
+++ b/src/main/java/com/be_provocation/domain/member/dto/response/MemberResponse.java
@@ -1,0 +1,21 @@
+package com.be_provocation.domain.member.dto.response;
+
+import com.be_provocation.domain.member.domain.Member;
+import lombok.Builder;
+
+@Builder
+public record MemberResponse(
+        Long memberId,
+        String nickname,
+        String profileImageUrl,
+        String gender
+) {
+    public static MemberResponse toDto(Member member) {
+        return MemberResponse.builder()
+                .memberId(member.getId())
+                .nickname(member.getNickname())
+                .profileImageUrl(member.getProfileImageUrl())
+                .gender(member.getGender().toString())
+                .build();
+    }
+}

--- a/src/main/java/com/be_provocation/domain/member/service/MemberService.java
+++ b/src/main/java/com/be_provocation/domain/member/service/MemberService.java
@@ -1,0 +1,16 @@
+package com.be_provocation.domain.member.service;
+
+import com.be_provocation.domain.member.domain.Member;
+import com.be_provocation.domain.member.dto.response.MemberResponse;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class MemberService {
+
+    public MemberResponse getMyProfile(Member member) {
+        return MemberResponse.toDto(member);
+    }
+
+}


### PR DESCRIPTION
## 🪺 Summary
홈화면에서 로그인한 사용자의 프로필이 최상단에 위치해야 합니다.
이때 필요한 내 프로필 조회 API를 작성했습니다. 
첨부된 사진을 보시면 꼭 필요한 닉네임과 프로필 사진 URL를 포함해서 필요할 것 같은 데이터를 함께 반환하고 있습니다.

## 🌱 Issue Number
- #36


## 🙏 To Reviewers
<img width="736" alt="image" src="https://github.com/user-attachments/assets/9374a43d-012b-44c9-8abc-8134a91b87d2">
