### PR TITLE
Bug: 룸메이트 상세보기 API에서 이미지 URL 누락 버그 수정

### DIFF
--- a/src/main/java/com/be_provocation/domain/info/dto/response/DetailResponse.java
+++ b/src/main/java/com/be_provocation/domain/info/dto/response/DetailResponse.java
@@ -17,7 +17,8 @@ public record DetailResponse(
               String sleepSensitivity,
               MBTI mbti,
               String desiredCloseness,
-              String department
+              String department,
+              String profileUrl
 
         ) {
     public static DetailResponse of (Member member, MyInfo myInfo) {
@@ -33,6 +34,7 @@ public record DetailResponse(
                 .mbti(myInfo.getMbti())
                 .desiredCloseness(myInfo.getDesiredCloseness().getDisplayName())
                 .department(myInfo.getDepartment())
+                .profileUrl(member.getProfileImageUrl())
                 .build();
     }
 }

--- a/src/main/java/com/be_provocation/domain/info/service/InfoService.java
+++ b/src/main/java/com/be_provocation/domain/info/service/InfoService.java
@@ -101,6 +101,7 @@ public class InfoService {
         MyInfo roommateInfo = myInfoRepository.findById(myInfoId)
                 .orElseThrow(() -> CheckmateException.from(ErrorCode.INFO_NOT_FOUND));
         Member roommate = roommateInfo.getMember();
+        log.info("상세보기");
         return DetailResponse.of(roommate, roommateInfo);
     }
 }


### PR DESCRIPTION
## 🪺 Summary
룸메이트 상세보기 api 에서 프로필 이미지 url이 누락된 버그를 수정했습니다.
사진처럼 이미지 url을 함께 반환하여 룸메이트마다 설정된 프로필을 동적으로 보여줄 수 있습니다.

## 🌱 Issue Number
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->
- #38


## 🙏 To Reviewers
![image](https://github.com/user-attachments/assets/10cbf515-a7bb-48f1-a45a-38dbab69a832)
