### PR TITLE
채팅 관련 API 로직과 응답 수정

### DIFF
--- a/src/main/java/com/be_provocation/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/be_provocation/domain/chat/controller/ChatRoomController.java
@@ -28,8 +28,8 @@ public class ChatRoomController {
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "채팅방 생성 API", description = "'대화 참여하기' 눌렀을 때, 채팅방을 생성하는 API입니다.")
     public ApiResponse<ChatRoomResDto> crateRoom(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                 @RequestParam Long youId) {
-        return new ApiResponse<>(chatRoomService.createChatRoom(userDetails.getMember(), youId));
+                                                 @RequestParam Long roommateId) {
+        return new ApiResponse<>(chatRoomService.createChatRoom(userDetails.getMember(), roommateId));
     }
 
     @GetMapping("/list")

--- a/src/main/java/com/be_provocation/domain/chat/dto/response/ChatMessageResDto.java
+++ b/src/main/java/com/be_provocation/domain/chat/dto/response/ChatMessageResDto.java
@@ -21,6 +21,8 @@ public class ChatMessageResDto {
 
     private String senderName;
 
+    private String senderProfileImageUrl;
+
     private LocalDateTime createdAt;
 
     public static ChatMessageResDto fromEntity(ChatMessage chatMessage) {
@@ -28,6 +30,7 @@ public class ChatMessageResDto {
                 .roomId(chatMessage.getChatRoom().getId())
                 .senderId(chatMessage.getSender().getId())
                 .senderName(chatMessage.getSender_name())
+                .senderProfileImageUrl(chatMessage.getSender().getProfileImageUrl())
                 .message(chatMessage.getMessage())
                 .createdAt(chatMessage.getCreatedAt())
                 .build();

--- a/src/main/java/com/be_provocation/domain/chat/dto/response/ChatRoomResDto.java
+++ b/src/main/java/com/be_provocation/domain/chat/dto/response/ChatRoomResDto.java
@@ -13,6 +13,7 @@ import java.time.LocalDateTime;
 @Builder
 public class ChatRoomResDto {
     private Long roomId;
+    private Long receiverId;
     private String receiverName;
     private String receiverProfileImageUrl;
     private LocalDateTime createdAt;
@@ -22,6 +23,7 @@ public class ChatRoomResDto {
     public static ChatRoomResDto fromEntity(ChatRoom savedChatRoom, Member roommate, ChatMessage chatMessage) {
         return ChatRoomResDto.builder()
                 .roomId(savedChatRoom.getId())
+                .receiverId(roommate.getId())
                 .receiverName(roommate.getNickname())
                 .receiverProfileImageUrl(roommate.getProfileImageUrl())
                 .createdAt(savedChatRoom.getCreatedAt())

--- a/src/main/java/com/be_provocation/domain/chat/dto/response/ChatRoomResDto.java
+++ b/src/main/java/com/be_provocation/domain/chat/dto/response/ChatRoomResDto.java
@@ -2,6 +2,7 @@ package com.be_provocation.domain.chat.dto.response;
 
 import com.be_provocation.domain.chat.entity.ChatMessage;
 import com.be_provocation.domain.chat.entity.ChatRoom;
+import com.be_provocation.domain.member.domain.Member;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -11,29 +12,22 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Builder
 public class ChatRoomResDto {
-    private Long id;
+    private Long roomId;
     private String receiverName;
+    private String receiverProfileImageUrl;
     private LocalDateTime createdAt;
     private String lastMessage;
     private LocalDateTime lastMessageAt;
 
-    public static ChatRoomResDto fromEntity(ChatRoom savedChatRoom, String receiverName, ChatMessage chatMessage) {
+    public static ChatRoomResDto fromEntity(ChatRoom savedChatRoom, Member roommate, ChatMessage chatMessage) {
         return ChatRoomResDto.builder()
-                .id(savedChatRoom.getId())
-                .receiverName(receiverName)
+                .roomId(savedChatRoom.getId())
+                .receiverName(roommate.getNickname())
+                .receiverProfileImageUrl(roommate.getProfileImageUrl())
                 .createdAt(savedChatRoom.getCreatedAt())
                 .lastMessage(chatMessage != null ? chatMessage.getMessage() : null)
                 .lastMessageAt(chatMessage != null ? chatMessage.getCreatedAt() : null)
                 .build();
     }
 
-    public static ChatRoomResDto fromEntity(ChatRoom savedChatRoom, String receiverName) {
-        return ChatRoomResDto.builder()
-                .id(savedChatRoom.getId())
-                .receiverName(receiverName)
-                .createdAt(savedChatRoom.getCreatedAt())
-                .lastMessage(null)
-                .lastMessageAt(null)
-                .build();
-    }
 }

--- a/src/main/java/com/be_provocation/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/be_provocation/domain/chat/service/ChatMessageService.java
@@ -10,6 +10,7 @@ import com.be_provocation.domain.chat.repository.ChatRoomRepository;
 import com.be_provocation.domain.member.domain.Member;
 import com.be_provocation.global.exception.CheckmateException;
 import com.be_provocation.global.exception.ErrorCode;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -25,6 +26,7 @@ public class ChatMessageService {
     private final ChatMessageRepository chatMessageRepository;
     private final ChatRoomRepository chatRoomRepository;
 
+    @Transactional
     public ChatMessageResDto sendMessage(ChatMessageReqDto chatMessageReqDto, CustomUserDetails userDetails) {
 
         Member sender = userDetails.getMember();
@@ -37,6 +39,7 @@ public class ChatMessageService {
         return ChatMessageResDto.fromEntity(chatMessage);
     }
 
+    @Transactional
     public List<ChatMessageResDto> getMessagesByRoom(Long roomId, CustomUserDetails userDetails) {
 
         Member member = userDetails.getMember();
@@ -50,6 +53,7 @@ public class ChatMessageService {
         return ChatMessageResDto.fromEntitieList(chatMessagesRoom);
     }
 
+    @Transactional
     public Optional<ChatMessage> getLastMessage(Long roomId) {
         return chatMessageRepository.findTopByChatRoomIdOrderByCreatedAtDesc(roomId);
     }

--- a/src/main/java/com/be_provocation/domain/chat/service/ChatParticipationService.java
+++ b/src/main/java/com/be_provocation/domain/chat/service/ChatParticipationService.java
@@ -16,7 +16,6 @@ import java.util.List;
 public class ChatParticipationService {
 
     private final ChatParticipationRepository chatParticipationRepository;
-    private final ChatRoomRepository chatRoomRepository;
 
     public void joinRoom(ChatRoom chatRoom, Member me, Member you) {
         ChatParticipation participation1 = chatParticipationRepository.save(ChatParticipation.builder()

--- a/src/main/java/com/be_provocation/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/be_provocation/domain/chat/service/ChatRoomService.java
@@ -6,6 +6,7 @@ import com.be_provocation.domain.chat.entity.ChatMessage;
 import com.be_provocation.domain.chat.entity.ChatParticipation;
 import com.be_provocation.domain.chat.entity.ChatRoom;
 import com.be_provocation.domain.chat.entity.RoomStatus;
+import com.be_provocation.domain.chat.repository.ChatParticipationRepository;
 import com.be_provocation.domain.chat.repository.ChatRoomRepository;
 import com.be_provocation.domain.member.domain.Member;
 import com.be_provocation.global.exception.CheckmateException;
@@ -46,6 +47,16 @@ public class ChatRoomService {
 
         Member roommate = customUserDetailService.loadUserById(roommateId).getMember();
 
+        // 이미 해당 룸메이트와 채팅방을 만든 적이 있다면 채팅방 정보를 바로 리턴
+        List<ChatParticipation> chatParticipationList = chatParticipationService.getParticipationByMember(me);
+        for (ChatParticipation chatParticipation : chatParticipationList) {
+            if (Objects.equals(chatParticipation.getChatRoom().getParticipation().get(0).getMember().getId(), roommate.getId()) ||
+                    Objects.equals(chatParticipation.getChatRoom().getParticipation().get(1).getMember().getId(), roommate.getId())) {
+                ChatRoom existingChatRoom = chatParticipation.getChatRoom();
+                return ChatRoomResDto.fromEntity(existingChatRoom, roommate, chatMessageService.getLastMessage(existingChatRoom.getId()).orElse(null));
+            }
+
+        }
         ChatRoom chatRoom = ChatRoom.builder()
                 .status(RoomStatus.ACTIVATE)
                 .createdAt(LocalDateTime.now())

--- a/src/main/java/com/be_provocation/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/be_provocation/domain/chat/service/ChatRoomService.java
@@ -10,7 +10,7 @@ import com.be_provocation.domain.chat.repository.ChatRoomRepository;
 import com.be_provocation.domain.member.domain.Member;
 import com.be_provocation.global.exception.CheckmateException;
 import com.be_provocation.global.exception.ErrorCode;
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -22,7 +22,6 @@ import java.util.Objects;
 import java.util.Optional;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 @Slf4j
 public class ChatRoomService {
@@ -35,29 +34,37 @@ public class ChatRoomService {
     /*
     채팅방 생성 + 참여자 추가
     */
-    public ChatRoomResDto createChatRoom(Member me, Long youId) {
+    @Transactional
+    public ChatRoomResDto createChatRoom(Member me, Long roommateId) {
 
         if (me == null) {
             throw CheckmateException.from(ErrorCode.ACCOUNT_USERNAME_EXIST);
         }
-        if (Objects.equals(youId, me.getId())) {
+        if (Objects.equals(roommateId, me.getId())) {
             throw CheckmateException.from(ErrorCode.CHAT_ROOM_SELF);
         }
 
-        Member you = customUserDetailService.loadUserById(youId).getMember();
+        Member roommate = customUserDetailService.loadUserById(roommateId).getMember();
 
         ChatRoom chatRoom = ChatRoom.builder()
                 .status(RoomStatus.ACTIVATE)
                 .createdAt(LocalDateTime.now())
                 .build();
+
+        // 채팅방 생성 후 저장
         ChatRoom savedChatRoom = chatRoomRepository.save(chatRoom);
-        chatParticipationService.joinRoom(chatRoom, me, you);
-        return ChatRoomResDto.fromEntity(savedChatRoom, you.getNickname());
+
+        // 생성된 채팅방의 참여자로 나랑 룸메를 저장
+        chatParticipationService.joinRoom(chatRoom, me, roommate);
+
+        // 아직 대화를 나누지 않아서 chat 내용은 null 처리
+        return ChatRoomResDto.fromEntity(savedChatRoom, roommate, null);
     }
 
-    public List<ChatRoomResDto> getAllRoom(Member member) {
+    @Transactional
+    public List<ChatRoomResDto> getAllRoom(Member me) {
 
-        List<ChatParticipation> chatParticipationList = chatParticipationService.getParticipationByMember(member);
+        List<ChatParticipation> chatParticipationList = chatParticipationService.getParticipationByMember(me);
         List<ChatRoomResDto> chatRooms = new ArrayList<>();
 
         for (ChatParticipation chatParticipation : chatParticipationList) {
@@ -70,9 +77,10 @@ public class ChatRoomService {
 
             Optional<ChatMessage> chatMessage = chatMessageService.getLastMessage(roomId);
             List<ChatParticipation> usersInRoom = chatRoom.getParticipation();
-            String receiverName = Objects.equals(usersInRoom.get(0).getId(), member.getId()) ? usersInRoom.get(0).getMember().getNickname() : usersInRoom.get(1).getMember().getNickname();
+            // 룸메 객체를 추출
+            Member roommate = Objects.equals(usersInRoom.get(0).getMember().getId(), me.getId()) ? usersInRoom.get(1).getMember() : usersInRoom.get(0).getMember();
 
-            chatRooms.add(ChatRoomResDto.fromEntity(chatRoom, receiverName, chatMessage.orElse(null)));
+            chatRooms.add(ChatRoomResDto.fromEntity(chatRoom, roommate, chatMessage.orElse(null)));
         }
         chatRooms.sort((o1, o2) -> {
             // o2의 메시지가 null인지 확인하고, null일 경우 생성시간으로 비교
@@ -84,6 +92,7 @@ public class ChatRoomService {
         return chatRooms;
     }
 
+    @Transactional
     // 유저들끼리 대화 중 문제가 생길 경우, 확인해야할 수 있으니 soft delete 만 지행
     public void deleteRoom(Long roomId, Member member) {
 
@@ -102,6 +111,7 @@ public class ChatRoomService {
         chatRoom.updateStatus(RoomStatus.DEACTIVATE); // `deactivate`로 변경하면서 `soft delete`만 진행
     }
 
+    @Transactional
     public ChatRoom getChatRoom(Long roomId) {
         return chatRoomRepository.findById(roomId).orElseThrow(() -> CheckmateException.from(ErrorCode.CHAT_ROOM_NOT_FOUND));
     }


### PR DESCRIPTION
## 🪺 Summary
1. 채팅방 응답에서 룸메이트의 프로필 이미지 url이 누락된 부분을 수정했습니다.
2. 채팅방 생성 로직이 이미 해당 룸메이트와 채팅방을 만들었을 경우, 또 생성이 되도록 구현이 되어있었습니다. 이를 확인해서 이미 채팅방이 존재하는 경우는 바로 정보를 리턴하도록 수정했습니다.

## 🌱 Issue Number
- #40 


## 🙏 To Reviewers
첫번째 사진은 로직 수정 전에 이미 특정 룸메이트와 채팅방을 만들었을 경우, 또 생성이 되는 결과입니다.
![image](https://github.com/user-attachments/assets/1256aa66-7911-46c9-a959-e15422451c61)

두번두번째 사진은 로직 수정 후에 이미 특정 룸메이트와 채팅방을 만들었을 경우, 그 채팅방의 정보를 반환해서 마지막 대화 정보를 확인할 수 있는 모습입니다.

![image](https://github.com/user-attachments/assets/b65eca71-ff11-47f9-bcc0-6809e71279b2)


@areian13 @fluoworite 프론트분들이 쉽게 연동하실 수 있게끔 피그마에 어떤 부분에서 어떤 api를 사용하셔야 되는지 빨간 글씨로 적어놨습니다. 참고 부탁드려요!

![image](https://github.com/user-attachments/assets/89e58783-0499-47dd-b506-004f42164e67)

