### PR TITLE
Fix: localDateTime 포맷팅과 roommateId를 응답에 포함하도록 수정

### DIFF
--- a/src/main/java/com/be_provocation/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/be_provocation/domain/chat/controller/ChatRoomController.java
@@ -24,7 +24,7 @@ public class ChatRoomController {
 
     private final ChatRoomService chatRoomService;
 
-    @PostMapping("/create")
+    @GetMapping("/create")
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "채팅방 생성 API", description = "'대화 참여하기' 눌렀을 때, 채팅방을 생성하는 API입니다.")
     public ApiResponse<ChatRoomResDto> crateRoom(@AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/com/be_provocation/domain/chat/dto/ChatRoomDto.java
+++ b/src/main/java/com/be_provocation/domain/chat/dto/ChatRoomDto.java
@@ -1,5 +1,6 @@
 package com.be_provocation.domain.chat.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.Size;
 import lombok.*;
 
@@ -14,5 +15,6 @@ public class ChatRoomDto {
     @Size(min = 1, max = 20)
     private String name;
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/be_provocation/domain/chat/dto/response/ChatMessageResDto.java
+++ b/src/main/java/com/be_provocation/domain/chat/dto/response/ChatMessageResDto.java
@@ -3,6 +3,7 @@ package com.be_provocation.domain.chat.dto.response;
 import com.be_provocation.domain.chat.entity.ChatMessage;
 import jakarta.validation.constraints.Size;
 import lombok.*;
+import com.fasterxml.jackson.annotation.JsonFormat;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -23,6 +24,7 @@ public class ChatMessageResDto {
 
     private String senderProfileImageUrl;
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createdAt;
 
     public static ChatMessageResDto fromEntity(ChatMessage chatMessage) {

--- a/src/main/java/com/be_provocation/domain/chat/dto/response/ChatRoomResDto.java
+++ b/src/main/java/com/be_provocation/domain/chat/dto/response/ChatRoomResDto.java
@@ -3,6 +3,7 @@ package com.be_provocation.domain.chat.dto.response;
 import com.be_provocation.domain.chat.entity.ChatMessage;
 import com.be_provocation.domain.chat.entity.ChatRoom;
 import com.be_provocation.domain.member.domain.Member;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -16,8 +17,10 @@ public class ChatRoomResDto {
     private Long receiverId;
     private String receiverName;
     private String receiverProfileImageUrl;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createdAt;
     private String lastMessage;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime lastMessageAt;
 
     public static ChatRoomResDto fromEntity(ChatRoom savedChatRoom, Member roommate, ChatMessage chatMessage) {

--- a/src/main/java/com/be_provocation/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/be_provocation/domain/chat/service/ChatMessageService.java
@@ -36,6 +36,8 @@ public class ChatMessageService {
 
         chatRoom.addMessage(chatMessage);
 
+        log.info("채팅 새로 생성됨.");
+
         return ChatMessageResDto.fromEntity(chatMessage);
     }
 

--- a/src/main/java/com/be_provocation/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/be_provocation/domain/chat/service/ChatRoomService.java
@@ -53,6 +53,7 @@ public class ChatRoomService {
             if (Objects.equals(chatParticipation.getChatRoom().getParticipation().get(0).getMember().getId(), roommate.getId()) ||
                     Objects.equals(chatParticipation.getChatRoom().getParticipation().get(1).getMember().getId(), roommate.getId())) {
                 ChatRoom existingChatRoom = chatParticipation.getChatRoom();
+                log.info("이미 존재함.");
                 return ChatRoomResDto.fromEntity(existingChatRoom, roommate, chatMessageService.getLastMessage(existingChatRoom.getId()).orElse(null));
             }
 
@@ -69,6 +70,7 @@ public class ChatRoomService {
         chatParticipationService.joinRoom(chatRoom, me, roommate);
 
         // 아직 대화를 나누지 않아서 chat 내용은 null 처리
+        log.info("새로 만들었음.");
         return ChatRoomResDto.fromEntity(savedChatRoom, roommate, null);
     }
 

--- a/src/main/java/com/be_provocation/domain/info/domain/MyInfo.java
+++ b/src/main/java/com/be_provocation/domain/info/domain/MyInfo.java
@@ -76,7 +76,7 @@ public class MyInfo extends BaseEntity {
     }
 
     public FilteringResponse toFilteringResponse() {
-        return new FilteringResponse(this.id, member.getNickname(), member.getProfileImageUrl(), this.mbti,
+        return new FilteringResponse(this.id, member.getId(), member.getNickname(), member.getProfileImageUrl(), this.mbti,
                 this.studentId, this.birthYear, this.department, this.desiredCloseness.getDisplayName());
     }
 

--- a/src/main/java/com/be_provocation/domain/info/dto/response/FilteringResponse.java
+++ b/src/main/java/com/be_provocation/domain/info/dto/response/FilteringResponse.java
@@ -4,6 +4,7 @@ import com.be_provocation.domain.info.domain.MBTI;
 
 public record FilteringResponse
         (Long myInfoId,
+         Long roommateId,
          String nickname,
          String profileImageUrl,
          MBTI mbti,


### PR DESCRIPTION
## 🪺 Summary
@areian13 님과 연동작업을 하던 중 요청하신 수정사항이 적용된 PR입니다.

- localDateTime에 프론트에서 원하는 포맷대로 반환될 수 있게끔 직렬화를 했습니다.
- API 연동이 연속적으로 이루어져야하는 부분에서 필요한 roommateId를 추가했습니다.

## 🌱 Issue Number
- #42
사진에 보시는 것처럼 시간 포맷팅이 정상처리 된 것을 볼 수 있습니다.
![image](https://github.com/user-attachments/assets/2864cba2-0023-487b-ae2a-140fb65e345c)

## 🙏 To Reviewers
